### PR TITLE
Unregister unused receivers and present interface to step count

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <application
         android:allowBackup="true"
+        android:name=".WalkWalkRevolutionApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/edu/ucsd/cse110/walkwalkrevolution/StepCountData.java
+++ b/app/src/main/java/edu/ucsd/cse110/walkwalkrevolution/StepCountData.java
@@ -1,0 +1,14 @@
+package edu.ucsd.cse110.walkwalkrevolution;
+
+public class StepCountData {
+
+    private static int value = 0;
+
+    public static void set(int stepCount) {
+        value = stepCount;
+    }
+
+    public static int get() {
+        return value;
+    }
+}

--- a/app/src/main/java/edu/ucsd/cse110/walkwalkrevolution/WalkWalkRevolutionApplication.java
+++ b/app/src/main/java/edu/ucsd/cse110/walkwalkrevolution/WalkWalkRevolutionApplication.java
@@ -1,0 +1,7 @@
+package edu.ucsd.cse110.walkwalkrevolution;
+
+import android.app.Application;
+
+public class WalkWalkRevolutionApplication extends Application {
+    public static StepCountData stepCount = new StepCountData();
+}

--- a/app/src/test/java/edu/ucsd/cse110/walkwalkrevolution/HomeActivityUnitTest.java
+++ b/app/src/test/java/edu/ucsd/cse110/walkwalkrevolution/HomeActivityUnitTest.java
@@ -45,7 +45,7 @@ public class HomeActivityUnitTest {
         ActivityScenario<HomeActivity> scenario = ActivityScenario.launch(intent);
         scenario.onActivity(activity -> {
             // Update the step count
-            activity.getStepCount();
+            activity.updateStepCount();
             TextView box_dailySteps = activity.findViewById(R.id.box_dailySteps);
             assertThat(box_dailySteps.getText().toString()).isEqualTo(String.valueOf(nextStepCount));
         });
@@ -58,7 +58,7 @@ public class HomeActivityUnitTest {
         ActivityScenario<HomeActivity> scenario = ActivityScenario.launch(intent);
         scenario.onActivity(activity -> {
             // Update the step count
-            activity.getStepCount();
+            activity.updateStepCount();
             TextView box_dailySteps = activity.findViewById(R.id.box_dailySteps);
             assertThat(box_dailySteps.getText().toString()).isEqualTo(String.valueOf(nextStepCount));
         });
@@ -71,7 +71,7 @@ public class HomeActivityUnitTest {
         ActivityScenario<HomeActivity> scenario = ActivityScenario.launch(intent);
         scenario.onActivity(activity -> {
             // Update the step count
-            activity.getStepCount();
+            activity.updateStepCount();
             TextView box_dailySteps = activity.findViewById(R.id.box_dailySteps);
             assertThat(box_dailySteps.getText().toString()).isEqualTo(String.valueOf(nextStepCount));
         });


### PR DESCRIPTION
Fix bug where broadcast receivers may be "leaked". Also gives a cleaner interface to get the step count.
https://app.zenhub.com/workspaces/walk-walk-revolution---team-8-5e3334b6ecc27a67186264fb/issues/ucsd-cse-110-2020/team-project-team8/26